### PR TITLE
modified show version app to give verbose level details

### DIFF
--- a/_examples/showver/main.go
+++ b/_examples/showver/main.go
@@ -40,7 +40,7 @@ func main() {
 	if err != nil {
 		log.Entry(ctx).Fatalln("ERROR: ShowVersion failed:", err)
 	}
-	log.Entry(ctx).Infof("VPP Version: %v", version.Version)
+	log.Entry(ctx).Infof("VPP Version: %v\nCompile Date: %v\nCompile Location: %v", version.Version, version.BuildDate, version.BuildDirectory)
 
 	// Cancel the context governing vpp's lifecycle and wait for it to exit
 	cancel()


### PR DESCRIPTION
Modified `show version` Output Looks like:
```
INFO[0000] VPP Version: 20.09-release
Compile Date: 2020-10-01T02:56:55
Compile Location: /w/workspace/vpp-merge-2009-ubuntu2004-x86_64 
```